### PR TITLE
Solved LGP

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,0 +1,6 @@
+DB_PASSWORD=D1ymf8wyQEGthFR1E9xhCq
+DB_USER=LTIdbUser
+DB_NAME=LTIdb
+DB_PORT=5432
+DATABASE_URL="postgresql://${DB_USER}:${DB_PASSWORD}@localhost:${DB_PORT}/${DB_NAME}"
+

--- a/backend/api-spec.yaml
+++ b/backend/api-spec.yaml
@@ -234,9 +234,9 @@ paths:
             schema:
               type: object
               properties:
-                positionId:
+                applicationId:
                   type: integer
-                  description: ID of the position
+                  description: ID of the application
                 currentInterviewStep:
                   type: integer
                   description: Current interview step

--- a/backend/api-spec.yaml
+++ b/backend/api-spec.yaml
@@ -185,4 +185,104 @@ paths:
           description: Invalid file type, only PDF and DOCX are allowed
         '500':
           description: Error during the file upload process
-
+  /position/{id}/candidates:
+    get:
+      summary: Get candidates by position
+      description: Retrieves all candidates for a specific position.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: ID of the position
+      responses:
+        '200':
+          description: List of candidates
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    fullName:
+                      type: string
+                    currentInterviewStep:
+                      type: string
+                    averageScore:
+                      type: number
+        '404':
+          description: Position not found
+        '500':
+          description: Internal server error
+  /candidates/{id}:
+    put:
+      summary: Update candidate stage
+      description: Updates the interview stage of a specific candidate.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+          description: ID of the candidate
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                positionId:
+                  type: integer
+                  description: ID of the position
+                currentInterviewStep:
+                  type: integer
+                  description: Current interview step
+      responses:
+        '200':
+          description: Candidate stage updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                      positionId:
+                        type: integer
+                      candidateId:
+                        type: integer
+                      applicationDate:
+                        type: string
+                        format: date-time
+                      currentInterviewStep:
+                        type: integer
+                      notes:
+                        type: string
+                        nullable: true
+                      interviews:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            interviewDate:
+                              type: string
+                              format: date-time
+                            interviewStep:
+                              type: string
+                            score:
+                              type: number
+                              nullable: true
+        '400':
+          description: Invalid input data
+        '404':
+          description: Candidate or application not found
+        '500':
+          description: Internal server error

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -29,6 +29,7 @@
                 "jest": "^29.7.0",
                 "prettier": "^3.2.5",
                 "prisma": "^5.13.0",
+                "supertest": "^7.0.0",
                 "ts-jest": "^29.1.2",
                 "ts-node": "^9.1.1",
                 "ts-node-dev": "^1.1.6",
@@ -1695,6 +1696,18 @@
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
             "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
         },
+        "node_modules/asap": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+            "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+            "dev": true
+        },
+        "node_modules/asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "dev": true
+        },
         "node_modules/babel-jest": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -2144,12 +2157,33 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
         },
+        "node_modules/combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
+            "dependencies": {
+                "delayed-stream": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
         "node_modules/commander": {
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
             "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/component-emitter": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+            "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/concat-map": {
@@ -2208,6 +2242,12 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
             "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+        },
+        "node_modules/cookiejar": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+            "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+            "dev": true
         },
         "node_modules/core-util-is": {
             "version": "1.0.3",
@@ -2329,6 +2369,15 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
         "node_modules/depd": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2353,6 +2402,16 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/dezalgo": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+            "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+            "dev": true,
+            "dependencies": {
+                "asap": "^2.0.0",
+                "wrappy": "1"
             }
         },
         "node_modules/diff": {
@@ -2821,6 +2880,12 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true
         },
+        "node_modules/fast-safe-stringify": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+            "dev": true
+        },
         "node_modules/fastq": {
             "version": "1.17.1",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -2927,6 +2992,34 @@
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
             "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
             "dev": true
+        },
+        "node_modules/form-data": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+            "dev": true,
+            "dependencies": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.8",
+                "mime-types": "^2.1.12"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/formidable": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.1.tgz",
+            "integrity": "sha512-WJWKelbRHN41m5dumb0/k8TeAx7Id/y3a+Z7QfhxP/htI9Js5zYaEDtG8uMgG0vM0lOlqnmjE99/kfpOYi/0Og==",
+            "dev": true,
+            "dependencies": {
+                "dezalgo": "^1.0.4",
+                "hexoid": "^1.0.0",
+                "once": "^1.4.0"
+            },
+            "funding": {
+                "url": "https://ko-fi.com/tunnckoCore/commissions"
+            }
         },
         "node_modules/forwarded": {
             "version": "0.2.0",
@@ -3140,6 +3233,15 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/hexoid": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+            "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/html-escaper": {
@@ -5320,6 +5422,51 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/superagent": {
+            "version": "9.0.2",
+            "resolved": "https://registry.npmjs.org/superagent/-/superagent-9.0.2.tgz",
+            "integrity": "sha512-xuW7dzkUpcJq7QnhOsnNUgtYp3xRwpt2F7abdRYIpCsAt0hhUqia0EdxyXZQQpNmGtsCzYHryaKSV3q3GJnq7w==",
+            "dev": true,
+            "dependencies": {
+                "component-emitter": "^1.3.0",
+                "cookiejar": "^2.1.4",
+                "debug": "^4.3.4",
+                "fast-safe-stringify": "^2.1.1",
+                "form-data": "^4.0.0",
+                "formidable": "^3.5.1",
+                "methods": "^1.1.2",
+                "mime": "2.6.0",
+                "qs": "^6.11.0"
+            },
+            "engines": {
+                "node": ">=14.18.0"
+            }
+        },
+        "node_modules/superagent/node_modules/mime": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+            "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+            "dev": true,
+            "bin": {
+                "mime": "cli.js"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/supertest": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.0.0.tgz",
+            "integrity": "sha512-qlsr7fIC0lSddmA3tzojvzubYxvlGtzumcdHgPwbFWMISQwL22MhM2Y3LNt+6w9Yyx7559VW5ab70dgphm8qQA==",
+            "dev": true,
+            "dependencies": {
+                "methods": "^1.1.2",
+                "superagent": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=14.18.0"
             }
         },
         "node_modules/supports-color": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -36,6 +36,7 @@
         "jest": "^29.7.0",
         "prettier": "^3.2.5",
         "prisma": "^5.13.0",
+        "supertest": "^7.0.0",
         "ts-jest": "^29.1.2",
         "ts-node": "^9.1.1",
         "ts-node-dev": "^1.1.6",

--- a/backend/src/application/services/candidateService.test.ts
+++ b/backend/src/application/services/candidateService.test.ts
@@ -1,0 +1,39 @@
+import { updateCandidateStage } from './candidateService';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+jest.mock('@prisma/client', () => {
+  const mockPrisma = {
+    application: {
+      findFirst: jest.fn(),
+      update: jest.fn(),
+    },
+  };
+  return { PrismaClient: jest.fn(() => mockPrisma) };
+});
+
+describe('updateCandidateStage', () => {
+  it('should update the candidate stage and return the updated application', async () => {
+    const mockApplication = {
+      id: 1,
+      positionId: 1,
+      candidateId: 1,
+      currentInterviewStep: 1,
+      applicationDate: new Date(),
+      notes: null,
+    };
+
+    jest.spyOn(prisma.application, 'findFirst').mockResolvedValue(mockApplication);
+    jest.spyOn(prisma.application, 'update').mockResolvedValue({
+      ...mockApplication,
+      currentInterviewStep: 2,
+    });
+
+    const result = await updateCandidateStage(1, 1, 2);
+    expect(result).toEqual(expect.objectContaining({
+      ...mockApplication,
+      currentInterviewStep: 2,
+    }));
+  });
+});

--- a/backend/src/application/services/candidateService.ts
+++ b/backend/src/application/services/candidateService.ts
@@ -3,6 +3,7 @@ import { validateCandidateData } from '../validator';
 import { Education } from '../../domain/models/Education';
 import { WorkExperience } from '../../domain/models/WorkExperience';
 import { Resume } from '../../domain/models/Resume';
+import { Application } from '../../domain/models/Application';
 
 export const addCandidate = async (candidateData: any) => {
     try {
@@ -61,5 +62,24 @@ export const findCandidateById = async (id: number): Promise<Candidate | null> =
     } catch (error) {
         console.error('Error al buscar el candidato:', error);
         throw new Error('Error al recuperar el candidato');
+    }
+};
+
+export const updateCandidateStage = async (id: number, positionId: number, currentInterviewStep: number) => {
+    try {
+        const application = await Application.findOneByPositionCandidateId(positionId, id);
+        if (!application) {
+            throw new Error('Application not found');
+        }
+
+        // Actualizar solo la etapa de la entrevista actual de la aplicación específica
+        application.currentInterviewStep = currentInterviewStep;
+
+        // Guardar la aplicación actualizada
+        await application.save();
+
+        return application;
+    } catch (error: any) {
+        throw new Error(error);
     }
 };

--- a/backend/src/application/services/candidateService.ts
+++ b/backend/src/application/services/candidateService.ts
@@ -65,9 +65,9 @@ export const findCandidateById = async (id: number): Promise<Candidate | null> =
     }
 };
 
-export const updateCandidateStage = async (id: number, positionId: number, currentInterviewStep: number) => {
+export const updateCandidateStage = async (id: number, applicationIdNumber: number, currentInterviewStep: number) => {
     try {
-        const application = await Application.findOneByPositionCandidateId(positionId, id);
+        const application = await Application.findOneByPositionCandidateId(applicationIdNumber, id);
         if (!application) {
             throw new Error('Application not found');
         }

--- a/backend/src/application/services/positionService.test.ts
+++ b/backend/src/application/services/positionService.test.ts
@@ -1,0 +1,43 @@
+import { getCandidatesByPositionService } from './positionService';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+jest.mock('@prisma/client', () => {
+  const mockPrisma = {
+    application: {
+      findMany: jest.fn(),
+    },
+  };
+  return { PrismaClient: jest.fn(() => mockPrisma) };
+});
+
+describe('getCandidatesByPositionService', () => {
+  it('should return candidates with their average scores', async () => {
+    const mockApplications = [
+      {
+        id: 1,
+        positionId: 1,
+        candidateId: 1,
+        applicationDate: new Date(),
+        currentInterviewStep: 1,
+        notes: null,
+        candidate: { firstName: 'John', lastName: 'Doe' },
+        interviewStep: { name: 'Technical Interview' },
+        interviews: [{ score: 5 }, { score: 3 }],
+      },
+    ];
+
+    jest.spyOn(prisma.application, 'findMany').mockResolvedValue(mockApplications);
+
+    const result = await getCandidatesByPositionService(1);
+    expect(result).toEqual([
+      {
+        fullName: 'John Doe',
+        currentInterviewStep: 'Technical Interview',
+        averageScore: 4,
+      },
+    ]);
+  });
+});
+

--- a/backend/src/application/services/positionService.ts
+++ b/backend/src/application/services/positionService.ts
@@ -1,0 +1,31 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+const calculateAverageScore = (interviews: any[]) => {
+    if (interviews.length === 0) return 0;
+    const totalScore = interviews.reduce((acc, interview) => acc + (interview.score || 0), 0);
+    return totalScore / interviews.length;
+};
+
+export const getCandidatesByPositionService = async (positionId: number) => {
+    try {
+        const applications = await prisma.application.findMany({
+            where: { positionId },
+            include: {
+                candidate: true,
+                interviews: true,
+                interviewStep: true
+            }
+        });
+
+        return applications.map(app => ({
+            fullName: `${app.candidate.firstName} ${app.candidate.lastName}`,
+            currentInterviewStep: app.interviewStep.name,
+            averageScore: calculateAverageScore(app.interviews)
+        }));
+    } catch (error) {
+        console.error('Error retrieving candidates by position:', error);
+        throw new Error('Error retrieving candidates by position');
+    }
+};

--- a/backend/src/domain/models/Application.ts
+++ b/backend/src/domain/models/Application.ts
@@ -50,4 +50,15 @@ export class Application {
         if (!data) return null;
         return new Application(data);
     }
+
+    static async findOneByPositionCandidateId(positionId: number, candidateId: number): Promise<Application | null> {
+        const data = await prisma.application.findFirst({
+            where: {
+                positionId: positionId,
+                candidateId: candidateId
+            }
+        });
+        if (!data) return null;
+        return new Application(data);
+    }
 }

--- a/backend/src/domain/models/Application.ts
+++ b/backend/src/domain/models/Application.ts
@@ -51,10 +51,10 @@ export class Application {
         return new Application(data);
     }
 
-    static async findOneByPositionCandidateId(positionId: number, candidateId: number): Promise<Application | null> {
+    static async findOneByPositionCandidateId(applicationIdNumber: number, candidateId: number): Promise<Application | null> {
         const data = await prisma.application.findFirst({
             where: {
-                positionId: positionId,
+                id: applicationIdNumber,
                 candidateId: candidateId
             }
         });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,6 +3,7 @@ import express from 'express';
 import { PrismaClient } from '@prisma/client';
 import dotenv from 'dotenv';
 import candidateRoutes from './routes/candidateRoutes';
+import positionRoutes from './routes/positionRoutes';
 import { uploadFile } from './application/services/fileUploadService';
 import cors from 'cors';
 
@@ -41,6 +42,9 @@ app.use('/candidates', candidateRoutes);
 
 // Route for file uploads
 app.post('/upload', uploadFile);
+
+// Route to get candidates by position
+app.use('/position', positionRoutes);
 
 app.use((req, res, next) => {
   console.log(`${new Date().toISOString()} - ${req.method} ${req.path}`);

--- a/backend/src/presentation/controllers/candidateController.test.ts
+++ b/backend/src/presentation/controllers/candidateController.test.ts
@@ -1,0 +1,35 @@
+import { updateCandidateStageController } from './candidateController';
+import { Request, Response } from 'express';
+import { updateCandidateStage } from '../../application/services/candidateService';
+
+jest.mock('../../application/services/candidateService');
+
+describe('updateCandidateStageController', () => {
+    it('should return 200 and updated candidate stage', async () => {
+      const req = { params: { id: '1' }, body: { positionId: 1, currentInterviewStep: 2 } } as unknown as Request;
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      } as unknown as Response;
+  
+      (updateCandidateStage as jest.Mock).mockResolvedValue({
+        id: 1,
+        positionId: 1,
+        candidateId: 1,
+        currentInterviewStep: 2,
+      });
+  
+      await updateCandidateStageController(req, res);
+  
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Candidate stage updated successfully',
+        data: {
+          id: 1,
+          positionId: 1,
+          candidateId: 1,
+          currentInterviewStep: 2,
+        },
+      });
+    });
+  });

--- a/backend/src/presentation/controllers/candidateController.test.ts
+++ b/backend/src/presentation/controllers/candidateController.test.ts
@@ -6,7 +6,7 @@ jest.mock('../../application/services/candidateService');
 
 describe('updateCandidateStageController', () => {
     it('should return 200 and updated candidate stage', async () => {
-      const req = { params: { id: '1' }, body: { positionId: 1, currentInterviewStep: 2 } } as unknown as Request;
+      const req = { params: { id: '1' }, body: { applicationId: 1, currentInterviewStep: 2 } } as unknown as Request;
       const res = {
         status: jest.fn().mockReturnThis(),
         json: jest.fn(),
@@ -14,7 +14,7 @@ describe('updateCandidateStageController', () => {
   
       (updateCandidateStage as jest.Mock).mockResolvedValue({
         id: 1,
-        positionId: 1,
+        applicationId: 1,
         candidateId: 1,
         currentInterviewStep: 2,
       });
@@ -26,7 +26,7 @@ describe('updateCandidateStageController', () => {
         message: 'Candidate stage updated successfully',
         data: {
           id: 1,
-          positionId: 1,
+          applicationId: 1,
           candidateId: 1,
           currentInterviewStep: 2,
         },

--- a/backend/src/presentation/controllers/candidateController.ts
+++ b/backend/src/presentation/controllers/candidateController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { addCandidate, findCandidateById } from '../../application/services/candidateService';
+import { addCandidate, findCandidateById, updateCandidateStage } from '../../application/services/candidateService';
 
 export const addCandidateController = async (req: Request, res: Response) => {
     try {
@@ -31,4 +31,26 @@ export const getCandidateById = async (req: Request, res: Response) => {
     }
 };
 
+export const updateCandidateStageController = async (req: Request, res: Response) => {
+    try {
+        const id = parseInt(req.params.id);
+        const { positionId, currentInterviewStep } = req.body;
+        const positionIdNumber = parseInt(positionId);
+        if (isNaN(positionIdNumber)) {
+            return res.status(400).json({ error: 'Invalid position ID format' });
+        }
+        const currentInterviewStepNumber = parseInt(currentInterviewStep);
+        if (isNaN(currentInterviewStepNumber)) {
+            return res.status(400).json({ error: 'Invalid currentInterviewStep format' });
+        }
+        const updatedCandidate = await updateCandidateStage(id, positionIdNumber, currentInterviewStepNumber);
+        res.status(200).json({ message: 'Candidate stage updated successfully', data: updatedCandidate });
+    } catch (error: unknown) {
+        if (error instanceof Error) {
+            res.status(400).json({ message: 'Error updating candidate stage', error: error.message });
+        } else {
+            res.status(400).json({ message: 'Error updating candidate stage', error: 'Unknown error' });
+        }
+    }
+};
 export { addCandidate };

--- a/backend/src/presentation/controllers/candidateController.ts
+++ b/backend/src/presentation/controllers/candidateController.ts
@@ -34,16 +34,16 @@ export const getCandidateById = async (req: Request, res: Response) => {
 export const updateCandidateStageController = async (req: Request, res: Response) => {
     try {
         const id = parseInt(req.params.id);
-        const { positionId, currentInterviewStep } = req.body;
-        const positionIdNumber = parseInt(positionId);
-        if (isNaN(positionIdNumber)) {
+        const { applicationId, currentInterviewStep } = req.body;
+        const applicationIdNumber = parseInt(applicationId);
+        if (isNaN(applicationIdNumber)) {
             return res.status(400).json({ error: 'Invalid position ID format' });
         }
         const currentInterviewStepNumber = parseInt(currentInterviewStep);
         if (isNaN(currentInterviewStepNumber)) {
             return res.status(400).json({ error: 'Invalid currentInterviewStep format' });
         }
-        const updatedCandidate = await updateCandidateStage(id, positionIdNumber, currentInterviewStepNumber);
+        const updatedCandidate = await updateCandidateStage(id, applicationIdNumber, currentInterviewStepNumber);
         res.status(200).json({ message: 'Candidate stage updated successfully', data: updatedCandidate });
     } catch (error: unknown) {
         if (error instanceof Error) {

--- a/backend/src/presentation/controllers/candidateController.ts
+++ b/backend/src/presentation/controllers/candidateController.ts
@@ -47,9 +47,13 @@ export const updateCandidateStageController = async (req: Request, res: Response
         res.status(200).json({ message: 'Candidate stage updated successfully', data: updatedCandidate });
     } catch (error: unknown) {
         if (error instanceof Error) {
-            res.status(400).json({ message: 'Error updating candidate stage', error: error.message });
+            if (error.message === 'Error: Application not found') {
+                res.status(404).json({ message: 'Application not found', error: error.message });
+            } else {
+                res.status(400).json({ message: 'Error updating candidate stage', error: error.message });
+            }
         } else {
-            res.status(400).json({ message: 'Error updating candidate stage', error: 'Unknown error' });
+            res.status(500).json({ message: 'Error updating candidate stage', error: 'Unknown error' });
         }
     }
 };

--- a/backend/src/presentation/controllers/positionController.test.ts
+++ b/backend/src/presentation/controllers/positionController.test.ts
@@ -1,0 +1,26 @@
+import { getCandidatesByPosition } from './positionController';
+import { Request, Response } from 'express';
+import { getCandidatesByPositionService } from '../../application/services/positionService';
+
+jest.mock('../../application/services/positionService');
+
+describe('getCandidatesByPosition', () => {
+  it('should return 200 and candidates data', async () => {
+    const req = { params: { id: '1' } } as unknown as Request;
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    } as unknown as Response;
+
+    (getCandidatesByPositionService as jest.Mock).mockResolvedValue([
+      { fullName: 'John Doe', currentInterviewStep: 'Technical Interview', averageScore: 4 },
+    ]);
+
+    await getCandidatesByPosition(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith([
+      { fullName: 'John Doe', currentInterviewStep: 'Technical Interview', averageScore: 4 },
+    ]);
+  });
+});

--- a/backend/src/presentation/controllers/positionController.ts
+++ b/backend/src/presentation/controllers/positionController.ts
@@ -1,0 +1,16 @@
+import { Request, Response } from 'express';
+import { getCandidatesByPositionService } from '../../application/services/positionService';
+
+export const getCandidatesByPosition = async (req: Request, res: Response) => {
+    try {
+        const positionId = parseInt(req.params.id);
+        const candidates = await getCandidatesByPositionService(positionId);
+        res.status(200).json(candidates);
+    } catch (error) {
+        if (error instanceof Error) {
+            res.status(500).json({ message: 'Error retrieving candidates', error: error.message });
+        } else {
+            res.status(500).json({ message: 'Error retrieving candidates', error: String(error) });
+        }
+    }
+};

--- a/backend/src/routes/candidateRoutes.ts
+++ b/backend/src/routes/candidateRoutes.ts
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { addCandidate, getCandidateById } from '../presentation/controllers/candidateController';
+import { addCandidate, getCandidateById, updateCandidateStageController } from '../presentation/controllers/candidateController';
 
 const router = Router();
 
@@ -18,5 +18,7 @@ router.post('/', async (req, res) => {
 });
 
 router.get('/:id', getCandidateById);
+
+router.put('/:id', updateCandidateStageController);
 
 export default router;

--- a/backend/src/routes/positionRoutes.ts
+++ b/backend/src/routes/positionRoutes.ts
@@ -1,0 +1,10 @@
+import { Request, Response } from 'express';
+import { Position } from '../domain/models/Position';
+import { getCandidatesByPosition } from '../presentation/controllers/positionController';
+
+
+const router = require('express').Router();
+
+router.get('/:id/candidates', getCandidatesByPosition);
+
+export default router;

--- a/prompts/prompts-LGP.md
+++ b/prompts/prompts-LGP.md
@@ -45,6 +45,6 @@
 
 13. vamos a realizar pruebas unitarias para asegurar el correcto funcionamiento de updateCandidateStageController y updateCandidateStage, quiero que sigas la misma estructura de los tests hechos para @positionController.test.ts  y @positionService.test.ts 
 
-
+14. ahora vamos a actualizar @api-spec.yaml  para añadir estos dos nuevos endpoints que hemos añadido
 
 Tickets => https://trello.com/b/QWY6fD2K/ats

--- a/prompts/prompts-LGP.md
+++ b/prompts/prompts-LGP.md
@@ -1,0 +1,50 @@
+# PROMPTS
+
+1. Quiero que actues como un desarrollador backend senior. Analiza el proyecto @backend y resume brevemente qué endpoints y funcionalidades tiene. Explicame brevemente en qué se basa el proyecto, qué funcionalidad tiene el sistema
+
+2. basándote en lo que ya tenemos implementando en @backend cuales crees que serían los siguientes pasos? no quiero que modifiques nada, solo dime cuál sería el siguiente endpoint para implementar
+
+3. vamos a comenzar implementando un nuevo endpoint GET /position/:id/candidates, aquí tienes más detalles:
+
+
+        Este endpoint recogerá todos los candidatos en proceso para una determinada posición, es decir, todas las aplicaciones para un determinado positionID. Debe proporcionar la siguiente información básica:
+
+        - Nombre completo del candidato (de la tabla candidate).
+        - current_interview_step: en qué fase del proceso está el candidato (de la tabla application).
+        -La puntuación media del candidato. Recuerda que cada entrevist (interview) realizada por el candidato tiene un score"
+
+    Quiero que actues como un arquitecto del software experimentado para definir el ticket para el desarrollo backend
+
+4. Perfecto, empecemos con la implementacion para obtener los candidatos por posición.
+
+5. ayudame a refactorizar @positionService.ts para mejorar la legibilidad del codigo, por ejemplo, añadiendo una funcion para calcular el averageScore
+
+6. cuando el usuario aún no ha hecho ningun entrevista el averageScore es null, vamos a modificar esto para devolver un valor más adecuado y tener integridad en los datos.
+
+7. teniendo en cuenta la estructura de datos @schema.prisma facilitame la consulta sql para obtener los candidatos que han aplicado a la position 1 y su puntuacion media. 
+
+8. vamos a realizar pruebas unitarias para asegurar el correcto funcionamiento de getCandidatesByPositionService y getCandidatesByPosition
+
+9. ahora vamos a implementar otro endpoint "PUT /candidate/:id"
+
+        Este endpoint actualizará la etapa del candidato movido. Permite modificar la fase actual del proceso de entrevista en la que se encuentra un candidato específico.
+
+    Quiero que actues como un arquitecto del software experimentado para definir el ticket para el desarrollo backend. Ten en cuenta que un candidato puede tener más de una aplicacion al haber aplicado a varias posiciones
+
+10. no tenemos que actualizar todas las etapas de todas las aplicaciones, habrá que indicar para qué aplicacion concreta se quiere actualizar la etapa
+
+11. Perfecto, empecemos con la implementacion para actualizar la etapa del candidato.
+
+12. vamos a modificar @candidateController.ts para que tenga en cuenta que en el body recibirá dos parámetros
+
+        {
+            "applicationId": 2,
+            "currentInterviewStep": 3
+        }
+
+
+13. vamos a realizar pruebas unitarias para asegurar el correcto funcionamiento de updateCandidateStageController y updateCandidateStage, quiero que sigas la misma estructura de los tests hechos para @positionController.test.ts  y @positionService.test.ts 
+
+
+
+Tickets => https://trello.com/b/QWY6fD2K/ats


### PR DESCRIPTION
Me planteé la posibilidad de que PUT /candidate/:id fuera un endpoint genérico para actualizar toda la información del candidato que recibiera por el body de la request, ya que parece ser un endpoint bastante genérico y podría englobar cualquier update en  candidate.

Pero analizando este caso de uso concreto, en el que la interfaz es tipo kanban y la acción de mover una aplicación de un estado a otro solo actualizará el current_interview_step, es más eficiente actualizar solamente Application.

En este caso concreto quizás lo mejor hubiera sido crear un endpoint propio para application PUT /application/:id
